### PR TITLE
Updated README to clarify require.main behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Rampant launches your Node.js application into a profiler session using [node-we
 1. Requires Mac OS X.
 2. Requires [Google Chrome Canary][canary].
 3. Does not work if your app depends on STDIN.
-4. Does not work if your script expects to be invoked directly (ie, it checks for `require.main === module`)
+4. Does not work if your script only runs if it's invoked directly (ie, it checks for `require.main === module` or `!module.parent`)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Rampant launches your Node.js application into a profiler session using [node-we
 1. Requires Mac OS X.
 2. Requires [Google Chrome Canary][canary].
 3. Does not work if your app depends on STDIN.
+4. Does not work if your script expects to be invoked directly (ie, it checks for `require.main === module`)
 
 ## Install
 


### PR DESCRIPTION
I ran into this when trying to run my app, which uses the method described here: http://nodejs.org/api/modules.html#modules_accessing_the_main_module to determine if it's been invoked directly (otherwise it just exports the express app - so it can be require'd by another script, test, etc if need be).

A lot of apps do this (or use the less recommended method of checking for `module.parent`), so would be good to fix this somehow so that apps that expect to be invoked directly can still work.
